### PR TITLE
Add directive plugin usage and odoo-context-gatherer agent

### DIFF
--- a/plugins/odoo-development/SKILL.md
+++ b/plugins/odoo-development/SKILL.md
@@ -1,9 +1,37 @@
 ---
 name: odoo-development
-description: This skill should be used when the user asks to "create an Odoo module", "generate Odoo code", "review Odoo module", "upgrade Odoo version", "Odoo best practices", "Odoo ORM patterns", "Odoo security", "Odoo views", "OWL components". Use for any Odoo 14-19 development tasks.
+description: |
+  MUST be loaded when ANY Odoo development task is detected.
+  CRITICAL: Claude MUST use this skill for ALL tasks involving:
+  - "odoo", "module", "model", "view", "field", "OWL", "manifest"
+  - ANY mention of Odoo versions (14, 15, 16, 17, 18, 19)
+  - "create odoo module", "generate odoo code", "review odoo module"
+  - "upgrade odoo", "odoo best practices", "odoo security"
+
+  ALWAYS trigger the odoo-context-gatherer agent BEFORE writing ANY Odoo code.
 ---
 
 # Odoo Development Skill Index
+
+> **CRITICAL**: Before writing ANY Odoo code, Claude MUST invoke the
+> `odoo-context-gatherer` agent to compile relevant patterns for the task.
+>
+> **MANDATORY WORKFLOW**:
+> 1. Detect/confirm Odoo version (NEVER skip)
+> 2. Invoke `odoo-development:odoo-context-gatherer` agent with task description
+> 3. Use returned context patterns for code generation
+> 4. NEVER skip step 2 - context gathering is REQUIRED
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  BEFORE generating Odoo code, you MUST:                                      ║
+║  1. Determine the target Odoo version                                        ║
+║  2. Invoke odoo-context-gatherer agent with task description                 ║
+║  3. Use the patterns returned by the agent                                   ║
+║                                                                              ║
+║  DO NOT generate Odoo code without context from the agent.                   ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
 
 > **Usage**: This is a lightweight discovery index. DO NOT read full skill files unless needed.
 > Use `Read` tool on specific file paths only when you need the detailed pattern.

--- a/plugins/odoo-development/agents/odoo-code-reviewer.md
+++ b/plugins/odoo-development/agents/odoo-code-reviewer.md
@@ -1,13 +1,34 @@
 ---
 name: odoo-code-reviewer
-description: Specialized agent for reviewing Odoo module code against best practices
+description: |
+  MUST be triggered when reviewing Odoo modules for code quality, security, performance, and version compliance.
+  ALWAYS use this agent for ANY Odoo code review task.
+  CRITICAL: DO NOT review Odoo code manually - this agent MUST be invoked.
+
+  <example>
+  Context: User asks to review Odoo code
+  user: "Review my Odoo module for security issues"
+  assistant: [MUST invoke odoo-code-reviewer agent]
+  <commentary>
+  Agent performs systematic review against version-specific best practices
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants code audit
+  user: "Check my module for performance problems"
+  assistant: [MUST invoke odoo-code-reviewer agent]
+  <commentary>
+  Agent checks for N+1 queries, missing indexes, inefficient patterns
+  </commentary>
+  </example>
+
 tools:
   - Read
   - Glob
   - Grep
   - WebFetch
-trigger:
-  description: Use this agent when reviewing Odoo modules for code quality, security, performance, and version compliance
+model: inherit
 color: blue
 ---
 

--- a/plugins/odoo-development/agents/odoo-context-gatherer.md
+++ b/plugins/odoo-development/agents/odoo-context-gatherer.md
@@ -1,0 +1,270 @@
+---
+name: odoo-context-gatherer
+description: |
+  MUST be triggered BEFORE any Odoo code generation or modification.
+  CRITICAL: This agent is MANDATORY for ALL Odoo development tasks.
+
+  ALWAYS invoke this agent when user mentions:
+  - Creating/modifying Odoo modules, models, views, fields
+  - OWL components, JavaScript, QWeb templates
+  - Security, access rights, record rules
+  - Workflows, automations, scheduled actions
+  - ANY Odoo version (14, 15, 16, 17, 18, 19)
+
+  DO NOT generate Odoo code without first calling this agent.
+
+  <example>
+  Context: User requests Odoo development
+  user: "Create a computed field for total amount"
+  assistant: [MUST invoke odoo-context-gatherer with task="computed field for total amount"]
+  <commentary>
+  Agent gathers computed field patterns, version-specific syntax, best practices
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to build an Odoo feature
+  user: "Add a sale order workflow with approval"
+  assistant: [MUST invoke odoo-context-gatherer with task="sale order workflow approval"]
+  <commentary>
+  Agent gathers workflow patterns, state management, mail integration, security
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to extend existing functionality
+  user: "Add custom fields to res.partner"
+  assistant: [MUST invoke odoo-context-gatherer with task="custom fields res.partner"]
+  <commentary>
+  Agent gathers inheritance patterns, field types, security considerations
+  </commentary>
+  </example>
+
+tools:
+  - Read
+  - Glob
+  - Grep
+model: inherit
+color: cyan
+---
+
+# Odoo Context Gatherer Agent
+
+You are an autonomous context-gathering agent that MUST compile all relevant Odoo development patterns before any code generation.
+
+## CRITICAL WORKFLOW
+
+### Step 1: Version Detection (MANDATORY)
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  NEVER proceed without confirming the Odoo version.                          ║
+║  Version determines ALL patterns, syntax, and best practices.                ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+**IF version is provided in prompt:**
+- Use that version directly
+
+**ELSE:**
+1. Search for `__manifest__.py` in current directory and subdirectories
+2. Extract version from `'version': 'X.0.Y.Z.Z'` (first number = Odoo version)
+3. IF no manifest found or version unclear: STOP and report that version is required
+4. NEVER guess the version - always confirm
+
+```bash
+# Version extraction pattern
+grep -r "version" --include="__manifest__.py" . | head -5
+```
+
+### Step 2: Task Analysis (MANDATORY)
+
+Analyze the task description to identify ALL required domains. Map keywords to skill files:
+
+| Keywords | Domain | Skill Files to Load |
+|----------|--------|---------------------|
+| field, char, integer, float, boolean, selection, text, html | Fields | `field-type-reference.md` |
+| computed, depends, inverse, store, search | Computed | `computed-field-patterns.md` |
+| many2one, many2many, one2many, relation, comodel | Relations | `field-type-reference.md` |
+| constraint, validation, check, _sql_constraints | Constraints | `constraint-patterns.md` |
+| onchange, domain, attrs, dynamic | Dynamic UI | `onchange-dynamic-patterns.md` |
+| view, form, tree, kanban, search, list | Views | `xml-view-patterns.md` |
+| security, access, rule, group, ir.model.access | Security | `odoo-security-guide.md` |
+| OWL, component, JavaScript, widget | Frontend | `odoo-owl-components.md` |
+| workflow, state, statusbar, activity | Workflow | `workflow-state-patterns.md` |
+| report, QWeb, PDF, print | Reports | `report-patterns.md` |
+| wizard, transient, dialog | Wizards | `wizard-patterns.md` |
+| cron, scheduled, automation, ir.cron | Automation | `cron-automation-patterns.md` |
+| mail, message, chatter, notification | Mail | `mail-notification-patterns.md` |
+| multi-company, company, allowed_company | Multi-company | `multi-company-patterns.md` |
+| inherit, extend, override, _inherit | Inheritance | `inheritance-patterns.md` |
+| controller, http, api, rest, json | Controllers | `controller-api-patterns.md` |
+| manifest, module, depends | Module | `odoo-module-generator.md` |
+| test, unittest | Testing | `odoo-test-patterns.md` |
+
+### Step 3: Pattern Gathering (MANDATORY)
+
+For EACH identified domain:
+
+1. **Read the skill file** from `${CLAUDE_PLUGIN_ROOT}/skills/`
+2. **Extract version-specific patterns** for the detected version
+3. **Note breaking changes** and deprecations for this version
+4. **Include copy-paste ready code snippets**
+
+**Version-specific skill file naming:**
+- General pattern: `skills/{pattern}.md`
+- Version-specific: `skills/{pattern}-{version}.md` (if exists)
+- Always check `skills/odoo-version-knowledge.md` for breaking changes
+
+### Step 4: Compile Context Output (MANDATORY)
+
+Return a structured context document in this EXACT format:
+
+```markdown
+## ODOO CONTEXT FOR: [task description]
+
+### Target Version: [X.0]
+
+### Version-Critical Information
+- [List any breaking changes or deprecations that affect this task]
+- [List version-specific syntax requirements]
+
+### Relevant Patterns
+
+#### [Domain 1: e.g., "Computed Fields"]
+**Pattern:**
+```python
+[Copy-paste ready code example]
+```
+**Version Note:** [Any version-specific info]
+
+#### [Domain 2: e.g., "Security"]
+**Pattern:**
+```python
+[Copy-paste ready code example]
+```
+**Version Note:** [Any version-specific info]
+
+[Continue for all relevant domains...]
+
+### Breaking Changes to Avoid
+- [Pattern X is REMOVED in version Y - use Z instead]
+- [Pattern A is DEPRECATED - prefer B]
+
+### Best Practices for This Task
+1. [Specific recommendation based on patterns]
+2. [Security consideration]
+3. [Performance tip if relevant]
+
+### Skill Files Consulted
+- `skills/file1.md` - [what was used from it]
+- `skills/file2.md` - [what was used from it]
+```
+
+## OUTPUT REQUIREMENTS
+
+1. **ALWAYS** include version number prominently at the top
+2. **ALWAYS** provide copy-paste ready code snippets (not explanations)
+3. **ALWAYS** note version-specific syntax differences
+4. **NEVER** include patterns from the wrong version
+5. **NEVER** include deprecated patterns without warning
+6. **LIMIT** output to directly relevant patterns (avoid context bloat)
+7. **PRIORITIZE** code examples over text explanations
+
+## VERSION-SPECIFIC CRITICAL DIFFERENCES
+
+### Odoo 14
+- Uses `@api.multi` (deprecated)
+- Uses `track_visibility='onchange'`
+- Uses `attrs={'invisible': [(...)]}`
+
+### Odoo 15
+- `@api.multi` REMOVED
+- Uses `tracking=True` instead of `track_visibility`
+- OWL 1.x syntax
+
+### Odoo 16
+- `Command` class for x2many operations
+- `attrs` deprecated (still works)
+- OWL 2.x migration
+
+### Odoo 17
+- `attrs` REMOVED - use direct attributes
+- `@api.model_create_multi` mandatory
+- Direct `invisible="expr"` syntax
+
+### Odoo 18
+- `_check_company_auto = True`
+- `check_company=True` on fields
+- Type hints recommended
+- `SQL()` builder recommended
+- `allowed_company_ids` in record rules
+
+### Odoo 19
+- Full type annotations REQUIRED
+- `SQL()` builder REQUIRED (no raw SQL)
+- SQL constraints use `models.Constraint()` class
+- `groups_id` cannot be set in `res.users.create()`
+- OWL 3.x patterns
+
+## EXAMPLE EXECUTION
+
+**Input:** "Create a computed field for total amount" (version: 18.0)
+
+**Output:**
+```markdown
+## ODOO CONTEXT FOR: computed field for total amount
+
+### Target Version: 18.0
+
+### Version-Critical Information
+- v18 recommends type hints on field definitions
+- v18 uses `@api.depends` decorator (unchanged from v14+)
+- `store=True` recommended for frequently accessed computed values
+
+### Relevant Patterns
+
+#### Computed Fields
+**Pattern:**
+```python
+from odoo import api, fields, models
+
+class MyModel(models.Model):
+    _name = 'my.model'
+    _description = 'My Model'
+
+    line_ids = fields.One2many('my.model.line', 'parent_id')
+    total_amount: float = fields.Float(
+        string='Total Amount',
+        compute='_compute_total_amount',
+        store=True,
+    )
+
+    @api.depends('line_ids.amount')
+    def _compute_total_amount(self):
+        for record in self:
+            record.total_amount = sum(record.line_ids.mapped('amount'))
+```
+**Version Note:** v18 recommends type hints (`: float`). `store=True` creates database column and index.
+
+### Breaking Changes to Avoid
+- None for basic computed fields in v18
+
+### Best Practices for This Task
+1. Use `store=True` if field is used in searches/reports
+2. Use `@api.depends` with specific field paths for efficiency
+3. Consider `compute_sudo=True` if computation needs elevated privileges
+
+### Skill Files Consulted
+- `skills/computed-field-patterns.md` - computed field syntax and decorators
+- `skills/odoo-version-knowledge.md` - v18 type hint recommendations
+```
+
+## AGENT INSTRUCTIONS
+
+1. **FIRST**: Detect or confirm Odoo version - NEVER proceed without it
+2. **ANALYZE**: Map task keywords to required skill files
+3. **READ**: Load only the relevant skill files
+4. **EXTRACT**: Pull version-specific patterns and code examples
+5. **COMPILE**: Format output exactly as specified
+6. **RETURN**: Structured context for main agent to use

--- a/plugins/odoo-development/agents/odoo-skill-finder.md
+++ b/plugins/odoo-development/agents/odoo-skill-finder.md
@@ -1,3 +1,29 @@
+---
+name: odoo-skill-finder
+description: |
+  MUST be used when odoo-context-gatherer needs to find specific pattern excerpts.
+  ALWAYS returns: FILE path + LINE range + max 50 lines of relevant code.
+
+  Use this agent for targeted pattern lookups when you need a specific code example
+  without loading entire skill files into context.
+
+  <example>
+  Context: Need specific computed field pattern
+  user: "How to create editable computed field"
+  assistant: [Invoke odoo-skill-finder to get precise excerpt]
+  <commentary>
+  Returns only the 20-50 lines needed, keeping context clean
+  </commentary>
+  </example>
+
+tools:
+  - Read
+  - Glob
+  - Grep
+model: inherit
+color: green
+---
+
 # Odoo Skill Finder Agent
 
 You are a specialized agent for finding relevant Odoo development patterns WITHOUT loading full content into the main context.

--- a/plugins/odoo-development/commands/odoo-module.md
+++ b/plugins/odoo-development/commands/odoo-module.md
@@ -1,6 +1,8 @@
 ---
 name: odoo-module
-description: Generate a new Odoo module with interactive configuration. Use when user asks to "create odoo module", "generate module", "scaffold odoo", "new odoo app".
+description: |
+  MUST be invoked when user asks to "create odoo module", "generate module", "scaffold odoo", "new odoo app".
+  CRITICAL: This command MUST invoke the odoo-context-gatherer agent before generating any code.
 arguments:
   - name: version
     description: Target Odoo version (14.0, 15.0, 16.0, 17.0, 18.0, 19.0)
@@ -31,6 +33,20 @@ Generate a production-ready Odoo module following version-specific best practice
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  Before generating any code, you MUST determine the target Odoo version.     ║
 ║  Then load the version-specific skill file.                                  ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## CRITICAL: MANDATORY AGENT INVOCATION
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  You MUST invoke the odoo-context-gatherer agent BEFORE generating code.     ║
+║  DO NOT proceed to code generation without context from this agent.          ║
+║                                                                              ║
+║  Invoke: Task tool with subagent_type="odoo-development:odoo-context-gatherer"║
+║  Prompt: "[User's task description]" + "version: [detected version]"         ║
+║                                                                              ║
+║  NEVER skip this step. Context gathering is MANDATORY.                       ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -156,8 +172,11 @@ Generate files in the current working directory:
 ## AI Agent Instructions
 
 1. **FIRST**: Determine Odoo version (ask if not provided)
-2. **THEN**: Load the version-specific module generator skill
-3. **GATHER**: Required information from user
-4. **GENERATE**: Version-appropriate code
-5. **VERIFY**: Code follows version-specific patterns
-6. **OUTPUT**: Complete module structure
+2. **MANDATORY**: Invoke `odoo-development:odoo-context-gatherer` agent with task description
+3. **THEN**: Load the version-specific module generator skill
+4. **GATHER**: Required information from user
+5. **GENERATE**: Version-appropriate code using patterns from context gatherer
+6. **VERIFY**: Code follows version-specific patterns
+7. **OUTPUT**: Complete module structure
+
+**CRITICAL**: Step 2 is MANDATORY. NEVER skip the context gatherer agent invocation.

--- a/plugins/odoo-development/commands/odoo-review.md
+++ b/plugins/odoo-development/commands/odoo-review.md
@@ -1,6 +1,9 @@
 ---
 name: odoo-review
-description: Review an Odoo module for best practices, security issues, and performance. Use when user asks to "review odoo module", "audit module", "check security", "analyze code quality".
+description: |
+  MUST be invoked when user asks to "review odoo module", "audit module", "check security", "analyze code quality".
+  CRITICAL: This command MUST invoke the odoo-code-reviewer agent for systematic review.
+  DO NOT perform manual reviews - ALWAYS use the specialized agent.
 arguments:
   - name: path
     description: Path to the module to review
@@ -30,6 +33,20 @@ Review an Odoo module for best practices, security vulnerabilities, performance 
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  Review criteria depend on the target Odoo version.                          ║
 ║  You MUST determine the version before reviewing.                            ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## CRITICAL: MANDATORY AGENT INVOCATION
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  You MUST invoke the odoo-code-reviewer agent to perform the review.         ║
+║  DO NOT perform manual code reviews - the agent has systematic checklists.   ║
+║                                                                              ║
+║  Invoke: Task tool with subagent_type="odoo-development:odoo-code-reviewer"  ║
+║  Prompt: "Review module at [path] for version [version]"                     ║
+║                                                                              ║
+║  NEVER skip this step. Agent-based review is MANDATORY.                      ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -176,8 +193,11 @@ Review the module against these categories:
 ## AI Agent Instructions
 
 1. **IDENTIFY**: Determine module path and target version
-2. **LOAD**: Version-specific review criteria
-3. **SCAN**: All module files systematically
-4. **CATEGORIZE**: Issues by severity and type
-5. **REPORT**: Structured review with actionable recommendations
-6. **PRIORITIZE**: Critical security issues first
+2. **MANDATORY**: Invoke `odoo-development:odoo-code-reviewer` agent
+3. **LOAD**: Version-specific review criteria (done by agent)
+4. **SCAN**: All module files systematically (done by agent)
+5. **CATEGORIZE**: Issues by severity and type (done by agent)
+6. **REPORT**: Structured review with actionable recommendations
+7. **PRIORITIZE**: Critical security issues first
+
+**CRITICAL**: Step 2 is MANDATORY. NEVER perform manual reviews without the agent.


### PR DESCRIPTION
- Add new odoo-context-gatherer agent that MUST be triggered before any Odoo code generation to compile relevant patterns
- Update SKILL.md with MUST/CRITICAL/ALWAYS directive language
- Update odoo-skill-finder agent with proper frontmatter and triggers
- Update odoo-code-reviewer agent with mandatory triggering
- Update odoo-module command with CRITICAL box requiring agent
- Update odoo-review command with mandatory agent invocation

The context gatherer agent:
- Auto-detects Odoo version from __manifest__.py
- Maps task keywords to relevant skill files
- Returns structured context with copy-paste ready patterns
- Includes version-specific syntax and breaking changes