### PR TITLE
Add common mistake: forgetting access rights on new models

### DIFF
--- a/plugins/odoo-development/skills/odoo-security-guide-14.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-14.md
@@ -236,12 +236,35 @@ class SecureModel(models.Model):
 
 ## v14 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Use `attrs` for view visibility conditions
 - [ ] Use `track_visibility` for field tracking
 - [ ] Single record create method signature
 - [ ] Do NOT use `@api.multi` (deprecated)
 - [ ] Use legacy chatter widgets
+
+## Common Security Mistakes in v14
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## Key v14 Patterns
 

--- a/plugins/odoo-development/skills/odoo-security-guide-15.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-15.md
@@ -223,11 +223,34 @@ class SecureModel(models.Model):
 
 ## v15 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Use `attrs` for view visibility conditions
 - [ ] Use `tracking=True` (NOT `track_visibility`)
 - [ ] Do NOT use `@api.multi` (removed)
 - [ ] Update chatter widgets (simplified)
+
+## Common Security Mistakes in v15
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## Key Differences from v14
 

--- a/plugins/odoo-development/skills/odoo-security-guide-16.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-16.md
@@ -248,12 +248,35 @@ class SecureModel(models.Model):
 
 ## v16 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Record rules use `company_ids` for multi-company
 - [ ] Prefer direct `invisible` attribute over `attrs`
 - [ ] Use `Command` class for x2many security operations
 - [ ] Use `tracking=True` instead of `track_visibility`
 - [ ] Prepare for `attrs` removal by using direct attributes
+
+## Common Security Mistakes in v16
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## Key Differences
 

--- a/plugins/odoo-development/skills/odoo-security-guide-17.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-17.md
@@ -306,13 +306,36 @@ class SecureModel(models.Model):
 
 ## v17 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Record rules use `company_ids` for multi-company
 - [ ] Views use direct `invisible` attribute (NOT `attrs`)
 - [ ] Use `@api.model_create_multi` for create methods
 - [ ] SQL queries use parameterized syntax
 - [ ] Button visibility uses `invisible` with Python expression
 - [ ] No `attrs` attribute anywhere in views
+
+## Common Security Mistakes in v17
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## Key Differences from v16
 

--- a/plugins/odoo-development/skills/odoo-security-guide-18.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-18.md
@@ -428,7 +428,7 @@ access_audit_auditor,audit.auditor,model_custom_audit_log,custom_module.group_au
 
 ## v18 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Multi-company models use `_check_company_auto = True`
 - [ ] Relational fields use `check_company=True` where appropriate
 - [ ] Record rules use `allowed_company_ids` for multi-company
@@ -438,6 +438,29 @@ access_audit_auditor,audit.auditor,model_custom_audit_log,custom_module.group_au
 - [ ] Audit logging for sensitive operations
 - [ ] sudo() usage is minimal and justified
 - [ ] No hardcoded IDs
+
+## Common Security Mistakes in v18
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## AI Agent Instructions (v18)
 

--- a/plugins/odoo-development/skills/odoo-security-guide-19.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-19.md
@@ -308,7 +308,7 @@ class AuditLog(models.Model):
 
 ## v19 Security Checklist
 
-- [ ] All models have `ir.model.access.csv` entries
+- [ ] **All models have `ir.model.access.csv` entries** ⚠️ Most common mistake - causes AccessError
 - [ ] Use `_check_company_auto = True` for multi-company models
 - [ ] Use `check_company=True` on relational fields
 - [ ] Use `allowed_company_ids` in record rules
@@ -317,6 +317,29 @@ class AuditLog(models.Model):
 - [ ] Use `SQL()` builder for ALL raw SQL (mandatory)
 - [ ] Views use direct `invisible` attribute
 - [ ] No `attrs` attribute in views
+
+## Common Security Mistakes in v19
+
+### 1. Forgetting Access Rights (Most Common!)
+
+**The Error:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+```
+
+**The Fix:**
+Always create access rights when adding a new model. See `odoo-security-guide-all.md` for detailed patterns and examples.
+
+**Quick Fix Template:**
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_admin,my.model.admin,model_my_model,base.group_system,1,1,1,1
+```
 
 ## Key Differences from v18
 

--- a/plugins/odoo-development/skills/odoo-security-guide-all.md
+++ b/plugins/odoo-development/skills/odoo-security-guide-all.md
@@ -161,6 +161,65 @@ manager_group = self.env.ref('my_module.group_manager')
 manager_group = self.env['res.groups'].browse(7)
 ```
 
+## Common Security Mistakes
+
+### Forgetting Access Rights on New Models
+
+**⚠️ CRITICAL MISTAKE:** The most common security error in Odoo development is forgetting to grant access rights to newly created models. This results in `AccessError` exceptions.
+
+**The Error You'll See:**
+```
+Access Error
+
+You are not allowed to modify 'Model Name' (model.technical.name) records.
+
+No group currently allows this operation.
+
+Contact your administrator to request access if necessary.
+```
+
+**Why This Happens:**
+- Odoo follows "secure by default" principle
+- When you create a new model, NO user (not even admin) has access by default
+- You MUST explicitly grant access rights via `ir.model.access.csv`
+
+**The Fix:**
+Always create `security/ir.model.access.csv` when adding a new model:
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model.user,model_my_model,base.group_user,1,1,1,0
+access_my_model_manager,my.model.manager,model_my_model,base.group_system,1,1,1,1
+```
+
+**Best Practice Checklist:**
+```
+When creating a new model:
+1. [ ] Create the model class in models/
+2. [ ] Create security/ir.model.access.csv (if not exists)
+3. [ ] Add access rights for at least base.group_user
+4. [ ] Add access rights for base.group_system (admin)
+5. [ ] Register security file in __manifest__.py 'data' section
+6. [ ] Test with non-admin user to verify access works
+```
+
+**Common Access Patterns:**
+
+```csv
+# Pattern 1: User can read/write, Manager can delete
+access_model_user,model.user,model_my_model,base.group_user,1,1,1,0
+access_model_manager,model.manager,model_my_model,my_module.group_manager,1,1,1,1
+
+# Pattern 2: Portal user read-only access
+access_model_portal,model.portal,model_my_model,base.group_portal,1,0,0,0
+access_model_user,model.user,model_my_model,base.group_user,1,1,1,1
+
+# Pattern 3: Public website access (read-only)
+access_model_public,model.public,model_my_model,base.group_public,1,0,0,0
+```
+
+**⚠️ REMEMBER:** This is not a bug in Odoo - it's a security feature. Always define access rights explicitly for every model you create.
+
 ## Multi-Company Security
 
 Multi-company is a critical security concern in Odoo.


### PR DESCRIPTION
## Summary

This PR addresses a critical and frequently occurring error in Odoo development where developers forget to grant access rights to newly created models, resulting in `AccessError` exceptions.

## Changes

### odoo-security-guide-all.md
- Added comprehensive "Common Security Mistakes" section
- Detailed explanation of the AccessError and why it occurs
- Provided best practice checklist for creating new models
- Included common access patterns with examples
- Emphasized that this is Odoo's "secure by default" principle, not a bug

### Version-Specific Guides (v14-19)
- Highlighted "forgetting access rights" as the #1 most common mistake in security checklists
- Added "Common Security Mistakes" section to each version guide
- Provided quick fix templates for immediate resolution

## Rationale

While the security guide already comprehensively covers access rights patterns and includes them in the checklist, this submission correctly identifies that the error message itself is valuable for developers who encounter it. By adding a prominent "Common Mistakes" section that mirrors the actual error message, developers can:

1. Quickly identify the root cause when they see the AccessError
2. Understand why it happens (secure by default principle)
3. Get actionable steps to fix it
4. Learn the patterns to prevent it in future development

This improvement makes the critical mistake more visible without duplicating existing content, following the pattern established in recent PRs for XPath and XML ID best practices.

## Testing

- Verified all 7 security guide files have been updated consistently
- Confirmed the new sections follow the established documentation patterns
- Ensured no duplication with existing access rights coverage

🤖 Generated with Claude Code