### PR TITLE
[FIX] Remove deprecated string attribute from tree tag examples for v17+

### DIFF
--- a/plugins/odoo-development/skills/xml-view-patterns.md
+++ b/plugins/odoo-development/skills/xml-view-patterns.md
@@ -200,7 +200,7 @@
     <field name="name">my.model.tree</field>
     <field name="model">my.model</field>
     <field name="arch" type="xml">
-        <tree string="My Models">
+        <tree>
             <field name="name"/>
             <field name="partner_id"/>
             <field name="date"/>
@@ -213,8 +213,7 @@
 
 ### Advanced Tree (v17+)
 ```xml
-<tree string="My Models"
-      decoration-danger="state == 'cancel'"
+<tree decoration-danger="state == 'cancel'"
       decoration-warning="state == 'draft'"
       decoration-success="state == 'done'"
       default_order="date desc">
@@ -564,3 +563,4 @@
 | Required | `attrs="{'required': [...]}"` | `required="expr"` |
 | Column hide | N/A | `column_invisible="True"` |
 | Optional cols | Limited | `optional="show/hide"` |
+| Tree `string` attr | `string="..."` supported | Deprecated (omit it) |


### PR DESCRIPTION
This pull request updates the documentation in `xml-view-patterns.md` to align with recent changes in Odoo's XML tree view conventions, specifically regarding the deprecation of the `string` attribute in tree views. The changes clarify recommended practices and update code examples to match Odoo v17+ standards.

**Updates for tree view conventions:**

* Removed the `string` attribute from `<tree>` elements in code examples to reflect its deprecation in Odoo v17+ (`plugins/odoo-development/skills/xml-view-patterns.md`). [[1]](diffhunk://#diff-cc70817a4e84da5a8531d53cc1480da73004c45e3686523b4e7a76cb951205feL203-R203) [[2]](diffhunk://#diff-cc70817a4e84da5a8531d53cc1480da73004c45e3686523b4e7a76cb951205feL216-R216)
* Added a note to the feature comparison table indicating that the `string="..."` attribute is now deprecated for tree views and should be omitted (`plugins/odoo-development/skills/xml-view-patterns.md`).

Fix issue #26