### PR TITLE
docs(odoo-development): forbid parallel file exploration during agent…

### DIFF
--- a/plugins/odoo-development/commands/odoo-module.md
+++ b/plugins/odoo-development/commands/odoo-module.md
@@ -50,6 +50,33 @@ Generate a production-ready Odoo module following version-specific best practice
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
+### NO PARALLEL EXPLORATION WHILE THE AGENT RUNS
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  When dispatching odoo-context-gatherer, you MUST NOT in the same message    ║
+║  (or while waiting for its result) run Bash/Read/Grep/Glob calls that        ║
+║  inspect the same modules, models, or files the agent will examine.          ║
+║  Duplicating its work wastes tokens and produces overlapping output the      ║
+║  user has to mentally merge.                                                 ║
+║                                                                              ║
+║  Allowed in parallel with the agent:                                         ║
+║    - Reading the project CLAUDE.md or memory files.                          ║
+║    - Reading the manifest of the NEW module being created (does not exist    ║
+║      yet, so the agent cannot examine it).                                   ║
+║    - Dispatching a SECOND agent on a DISJOINT subject.                       ║
+║                                                                              ║
+║  Forbidden in parallel with the agent:                                       ║
+║    - Grepping or listing files in the modules named in the agent prompt.    ║
+║    - Reading model/view/security files of the same Odoo apps the agent is   ║
+║      gathering patterns for.                                                 ║
+║    - Cat-ing manifests of modules the agent has been asked to study.        ║
+║                                                                              ║
+║  Default behavior: dispatch the agent ALONE, wait for its report, THEN       ║
+║  explore anything the report did not cover.                                  ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
 ## Execution Flow
 
 ### Step 1: Determine Odoo Version
@@ -173,10 +200,15 @@ Generate files in the current working directory:
 
 1. **FIRST**: Determine Odoo version (ask if not provided)
 2. **MANDATORY**: Invoke `odoo-development:odoo-context-gatherer` agent with task description
+   - Dispatch the agent **alone** in its own tool-use message.
+   - Do NOT in the same message (or while waiting for the result) run Bash/Read/Grep/Glob
+     against modules, models, or files the agent will examine. See "NO PARALLEL EXPLORATION".
+   - Wait for the agent's report before any further file inspection.
 3. **THEN**: Load the version-specific module generator skill
 4. **GATHER**: Required information from user
 5. **GENERATE**: Version-appropriate code using patterns from context gatherer
 6. **VERIFY**: Code follows version-specific patterns
 7. **OUTPUT**: Complete module structure
 
-**CRITICAL**: Step 2 is MANDATORY. NEVER skip the context gatherer agent invocation.
+**CRITICAL**: Step 2 is MANDATORY. NEVER skip the context gatherer agent invocation,
+and NEVER duplicate its work with parallel file exploration.

--- a/plugins/odoo-development/commands/odoo-review.md
+++ b/plugins/odoo-development/commands/odoo-review.md
@@ -50,6 +50,31 @@ Review an Odoo module for best practices, security vulnerabilities, performance 
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
+### NO PARALLEL EXPLORATION WHILE THE AGENT RUNS
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  When dispatching odoo-code-reviewer, you MUST NOT in the same message       ║
+║  (or while waiting for its result) run Bash/Read/Grep/Glob calls that        ║
+║  inspect the module being reviewed. The reviewer agent reads those files     ║
+║  systematically; duplicating its work wastes tokens and produces overlapping ║
+║  output.                                                                     ║
+║                                                                              ║
+║  Allowed in parallel with the agent:                                         ║
+║    - Reading project CLAUDE.md or memory files.                              ║
+║    - Dispatching a SECOND agent on a DISJOINT subject (e.g. a different      ║
+║      module).                                                                ║
+║                                                                              ║
+║  Forbidden in parallel with the agent:                                       ║
+║    - Reading any file inside the module path passed to the agent.            ║
+║    - Grepping for patterns the reviewer would already check.                 ║
+║    - Cat-ing the manifest of the module under review.                        ║
+║                                                                              ║
+║  Default behavior: dispatch the reviewer ALONE, wait for its report, THEN    ║
+║  inspect anything the report did not cover.                                  ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
 ## Execution Flow
 
 ### Step 1: Identify Module and Version
@@ -194,10 +219,15 @@ Review the module against these categories:
 
 1. **IDENTIFY**: Determine module path and target version
 2. **MANDATORY**: Invoke `odoo-development:odoo-code-reviewer` agent
+   - Dispatch the agent **alone** in its own tool-use message.
+   - Do NOT in the same message (or while waiting for the result) run Bash/Read/Grep/Glob
+     against the module being reviewed. See "NO PARALLEL EXPLORATION".
+   - Wait for the agent's report before any further file inspection.
 3. **LOAD**: Version-specific review criteria (done by agent)
 4. **SCAN**: All module files systematically (done by agent)
 5. **CATEGORIZE**: Issues by severity and type (done by agent)
 6. **REPORT**: Structured review with actionable recommendations
 7. **PRIORITIZE**: Critical security issues first
 
-**CRITICAL**: Step 2 is MANDATORY. NEVER perform manual reviews without the agent.
+**CRITICAL**: Step 2 is MANDATORY. NEVER perform manual reviews without the agent,
+and NEVER duplicate its work with parallel file exploration.


### PR DESCRIPTION
… dispatch

Add an explicit "NO PARALLEL EXPLORATION" rule to /odoo-module and /odoo-review so that, when the mandatory subagent (odoo-context-gatherer or odoo-code-reviewer) is dispatched, the parent assistant does not also run Bash/Read/Grep/Glob in the same message against the same modules and files. This duplication wastes tokens and produces overlapping output the user has to mentally merge.

The rule is reinforced both in the CRITICAL callout block and in the numbered "AI Agent Instructions" at the end of each command, with explicit allow/forbid lists so the assistant can judge edge cases (a second disjoint agent or reading the project CLAUDE.md is fine; reading model/view/security files of the same apps the agent is studying is not).